### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -3,6 +3,8 @@ import walkPath from './utility/walkPath.js';
 
 const buildNew = (key) => !isNaN(parseInt(key)) ? [] : {};
 
+const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key);
+
 /**
  * Sets a nested value in an object. Keys in the path that don't exist at any point in the object will be created and added to the object once.
  *
@@ -49,7 +51,7 @@ export default (object, path, value) => {
 			object[key] = value;
 			return true;
 		}
-
+		
 		if (object[key] === undefined) {
 			if (!baseItem) {
 				baseItem = object;
@@ -62,6 +64,7 @@ export default (object, path, value) => {
 			}
 		}
 		else {
+			if (isPrototypePolluted(key)) return;
 			object = object[key];
 		}
 	});


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-agent` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-agent

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.mjs
import { set } from 'object-agent';
var obj = {}
console.log("Before : " + {}.polluted);
set(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);

```
2. Execute the following commands in terminal:
```bash
npm i object-agent # Install affected module
node poc.mjs #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![object-agent-fix](https://user-images.githubusercontent.com/43996156/102956434-2353ab80-44fe-11eb-8c3d-117cb5ada02a.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
